### PR TITLE
Update Readme.md - wrong media mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ if (localStorage[roomName]) {
 else {
   // Create a session that will attempt to transmit streams directly between
   // clients. If clients cannot connect, the session uses the OpenTok TURN server:
-  opentok.createSession({mediaMode:"routed"}, function(err, session) {
+  opentok.createSession({mediaMode:"relayed"}, function(err, session) {
     if (err) {
       console.log(err);
       res.status(500).send({error: 'createSession error:', err});


### PR DESCRIPTION
> Routed — The session uses the OpenTok Media Router to route audio-video streams between clients. 
> Relayed — In a relayed session, clients will attempt to send audio-video streams directly between each other (peer-to-peer).

```
// Create a session that will attempt to transmit streams directly between
// clients. If clients cannot connect, the session uses the OpenTok TURN server:
```

According to the documentation in the code, the expected `mediaMode` was `relayed` IMO.