### PR TITLE
VIDAPI-126 - Remove maxDuration

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -133,7 +133,7 @@ router.post('/captions/start', async (req, res) => {
     sessionId,
     token: req.body.token,
     languageCode: 'en-US',
-    maxDuration: 36000,
+    maxDuration: 14400,
     partialCaptions: 'true',
   };
 
@@ -311,7 +311,7 @@ router.post('/render', async (req, res) => {
     sessionId: req.body.sessionId,
     token: req.body.token,
     "url": "https://www.google.com",
-    maxDuration: 14400,
+    maxDuration: 36000,
     "resolution": "1280x720",
     "properties": {
       name: "Composed stream for Live event",

--- a/routes/index.js
+++ b/routes/index.js
@@ -311,6 +311,7 @@ router.post('/render', async (req, res) => {
     sessionId: req.body.sessionId,
     token: req.body.token,
     "url": "https://www.google.com",
+    maxDuration: 14400,
     "resolution": "1280x720",
     "properties": {
       name: "Composed stream for Live event",

--- a/routes/index.js
+++ b/routes/index.js
@@ -311,7 +311,6 @@ router.post('/render', async (req, res) => {
     sessionId: req.body.sessionId,
     token: req.body.token,
     "url": "https://www.google.com",
-    maxDuration: 36000,
     "resolution": "1280x720",
     "properties": {
       name: "Composed stream for Live event",


### PR DESCRIPTION
Updated the MaxDuration value from the Start Captions request. The service will use the new default.

Please see [this Slack thread](https://vonage.slack.com/archives/CCX1CLQKV/p1678894710036699) for more info