### PR TITLE
Captions API - Change to captions stop

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -160,7 +160,7 @@ router.post('/captions/:captionsId/stop', postBodyParser, async (req, res) => {
         'Content-Type': 'application/json',
       },
     });
-    res.sendStatus(captionResponse.status);
+    res.send({ status: captionResponse.status });
   } catch (err) {
     console.warn(err);
     res.status(500);


### PR DESCRIPTION
This PR changes the response to the `captionsId/:captionId/stop` route to return JSON instead of status. 