### PR TITLE
 Remove maxDuration from captions REST call 

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,6 @@ router.post('/captions/start', async function (req, res) {
     sessionId: req.body.sessionId,
     token: req.body.token,
     languageCode: 'en-US',
-    maxDuration: 14400,
     partialCaptions: 'true',
   };
 


### PR DESCRIPTION
We no longer want to specify maxDuration, as the server will always default to the correct highest value.