### PR TITLE
Captions - Max Duration Remove

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -122,7 +122,6 @@ router.post('/captions/start', async (req, res) => {
     sessionId,
     token: req.body.token,
     languageCode: 'en-US',
-    maxDuration: 14400,
     partialCaptions: 'true',
   };
 


### PR DESCRIPTION
This PR removes the `maxDuration` property in the actual code and not just the `readme` as I did in the previous PR. Oops.